### PR TITLE
Minimal failing example for forward declared unique_ptr

### DIFF
--- a/Bar.h
+++ b/Bar.h
@@ -1,6 +1,4 @@
 
 #pragma once
 
-namespace A::B::C {
 class Bar{};
-}

--- a/Baz.h
+++ b/Baz.h
@@ -1,5 +1,0 @@
-#pragma once
-
-namespace A::B::D {
-class Baz{};
-} // namespace A::B::D

--- a/Foo.cpp
+++ b/Foo.cpp
@@ -1,10 +1,12 @@
 #include "Foo.h"
-#include "Bar.h"
-#include "Baz.h"
 
-namespace A::B::C
+#include <memory>
+
+#include "Bar.h"
+
+Foo::Foo()
 {
-Foo::~Foo() = default;
+    m_bar = std::make_unique<Bar>();    
 }
 
-int main(){}
+Foo::~Foo() = default;

--- a/Foo.h
+++ b/Foo.h
@@ -1,22 +1,14 @@
-#include <string>
 #include <memory>
 
+// #include "Bar.h" // Comment this out for forward declaration
 
-namespace A::B::D {
-class Baz;
-} // namespace A::B::D
-
-namespace A::B::C {
-class Bar;
-class Foo_I {};
-class Foo : public Foo_I
+class Bar; // Un-comment for forward declaration
+class Foo
 {
 public:
-	Foo(std::string s, uint16_t p);
+	Foo();
 	~Foo();
 
 private:
-	std::unique_ptr<D::Baz> m_db{ nullptr }; // this is ok
-	std::unique_ptr<Bar> m_bar{ nullptr }; // this gives error
+	std::unique_ptr<Bar> m_bar{ nullptr };
 };
-} // namespace A::B::C

--- a/main.cpp
+++ b/main.cpp
@@ -1,0 +1,7 @@
+#include "Foo.h"
+
+int main(int argc, char const *argv[])
+{
+    Foo f; // this gives error
+    return 0;
+}


### PR DESCRIPTION
Tried with G++ 7.3.1 20180303 (Red Hat 7.3.1-5)

I am not familiar with meson so you would have to modify it now that I have added main.cpp